### PR TITLE
Add better name matching for python class level configs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,9 +40,7 @@ or Yaml.
 
 Python::
 
-    class Config(object):
-        DEBUG = False
-        TESTING = False
+    from flask.ext.environments import BaseConfig as Config
 
     class Development(Config):
         DEBUG = True
@@ -69,10 +67,10 @@ Yaml::
 Next, create your application and initialize the Environments extensions::
 
     from flask import Flask
-    from flask_environments import Environments
+    from flask.ext.environments import Environments
 
     app = Flask(__name__)
-    env = Environments(self.app)
+    env = Environments(app)
 
 Then simply use the `from_object` method or the `from_yaml` method to load
 the configuration::
@@ -90,7 +88,7 @@ To change the default environment or the environment varibale name pass the `var
 or `default_env` parameters to the Environments constructor like so::
 
     from flask import Flask
-    from flask_environments import Environments
+    from flask.ext.environments import Environments
 
     app = Flask(__name__)
-    env = Environments(self.app, var_name='CUSTOM_VAR_NAME', default_env='CUSTOM_ENV')
+    env = Environments(app, var_name='CUSTOM_VAR_NAME', default_env='CUSTOM_ENV')

--- a/flask_environments.py
+++ b/flask_environments.py
@@ -18,8 +18,8 @@ from inspect import getmembers, isclass
 
 class BaseConfig(object):
    """ Base Config class from which to subclass for which to derive from """
-   DEBUG = True
-   TESTING = True
+   DEBUG = False
+   TESTING = False
 
 
 class Environments(object):

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,9 +1,4 @@
-
-
-class Config(object):
-    DEBUG = False
-    TESTING = False
-
+from flask.ext.environments import BaseConfig as Config
 
 class Development(Config):
     DEBUG = True


### PR DESCRIPTION
Added BaseConfig class from which to subclass from, this is required for inspect predicate to match. This can still be subclass from an "Application" or "Project-level" Base Config class just fine.

Added one more sane default possible name: `self.env.upper()`

Updated docs and fixed typos
