### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/flask_environments.py
+++ b/flask_environments.py
@@ -66,7 +66,7 @@ class Environments(object):
 
         app = self.get_app()
 
-        for key in c.iterkeys():
+        for key in c.keys():
             if key.isupper():
                 app.config[key] = c[key]
 


### PR DESCRIPTION
Replaced `iterkeys()` with `keys()`, since it seems to be the easiest fix for Python 3 compatibility. I don't think the memory footprint of such a list would anyway be significant performance-wise.
