### PR TITLE
use dict.keys() instead of dict.iterkeys() to support both python 2 and 3

### DIFF
--- a/flask_environments.py
+++ b/flask_environments.py
@@ -66,7 +66,7 @@ class Environments(object):
 
         app = self.get_app()
 
-        for key in c.iterkeys():
+        for key in c.keys():
             if key.isupper():
                 app.config[key] = c[key]
 


### PR DESCRIPTION
use dict.keys() instead of dict.iterkeys() to support both python 2 and 3
